### PR TITLE
Bumped the php version to allow PHP ~7.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,18 @@
 {
-    "name": "creativestyle/magesuite-translation-center",
-    "description": "Translation Center extension for Magento 2",
-    "type": "magento2-module",
-    "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
-        "google/apiclient": "^2.0",
-        "mikey179/vfsStream": "^1.3"
-    },
-    "autoload": {
-        "files": [ "registration.php" ],
-        "psr-4": {
-            "MageSuite\\TranslationCenter\\": ""
-        }
+  "name": "creativestyle/magesuite-translation-center",
+  "description": "Translation Center extension for Magento 2",
+  "type": "magento2-module",
+  "require": {
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0",
+    "google/apiclient": "^2.0",
+    "mikey179/vfsStream": "^1.3"
+  },
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "MageSuite\\TranslationCenter\\": ""
     }
+  }
 }


### PR DESCRIPTION
Hello, 

PR to fix https://github.com/magesuite/magesuite/issues/42 

Since Magento supports PHP 7.3, it would be a good idea to add PHP 7.3 to the require of this package. 

Thank you ! 